### PR TITLE
fix issue #1

### DIFF
--- a/corpus.h
+++ b/corpus.h
@@ -4,6 +4,7 @@
 #define CORPUS_H
 
 #include <vector>
+#include <stddef.h>
 
 using namespace std;
 


### PR DESCRIPTION
This PR fixes https://github.com/Blei-Lab/ctr/issues/1 by adding

`#include <cstddef.h>` in `corpus.h`

as described in http://stackoverflow.com/questions/924664/why-is-null-undeclared.
